### PR TITLE
☺Rework scheduling mechanism.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsesc": "^1.0.0",
     "lodash.assign": "^4.0.0",
     "lodash.capitalize": "^4.0.1",
+    "lodash.clone": "^4.4.1",
     "lodash.debounce": "^4.0.0",
     "lodash.filter": "^4.2.1",
     "lodash.foreach": "^4.3.0",

--- a/src/pages/content-edit/head.css
+++ b/src/pages/content-edit/head.css
@@ -129,6 +129,7 @@
 }
 
 .invalidDate {
+    composes: date;
     border: thin solid #e61010;
     color: #e61010;
 }
@@ -139,9 +140,11 @@
     color: grey;
     font-style: italic;
 }
+
 .clearSchedule:hover {
     text-decoration: underline;
 }
+
 .clearSchedule:disabled {
     display: none;
 }

--- a/src/pages/content-edit/head.css
+++ b/src/pages/content-edit/head.css
@@ -135,14 +135,18 @@
 }
 
 .clearSchedule {
-    background: transparent;
+    composes: button from buttons_css;
+
+    background: #afafaf;
     border: none;
-    color: grey;
-    font-style: italic;
+    color: #fff;
+    text-transform: capitalize;
+    text-decoration: none;
 }
 
 .clearSchedule:hover {
-    text-decoration: underline;
+    background: #8f8f8f;
+    text-decoration: none;
 }
 
 .clearSchedule:disabled {

--- a/src/pages/content-edit/head.css
+++ b/src/pages/content-edit/head.css
@@ -133,7 +133,15 @@
     color: #e61010;
 }
 
-.disabledBtn {
-    cursor: default;
-    opacity: 0.5;
+.clearSchedule {
+    background: transparent;
+    border: none;
+    color: grey;
+    font-style: italic;
+}
+.clearSchedule:hover {
+    text-decoration: underline;
+}
+.clearSchedule:disabled {
+    display: none;
 }

--- a/src/pages/content-edit/head.css
+++ b/src/pages/content-edit/head.css
@@ -127,3 +127,13 @@
 .end {
     flex: 1 0 50%;
 }
+
+.invalidDate {
+    border: thin solid #e61010;
+    color: #e61010;
+}
+
+.disabledBtn {
+    cursor: default;
+    opacity: 0.5;
+}

--- a/src/pages/content-edit/head.js
+++ b/src/pages/content-edit/head.js
@@ -3,53 +3,61 @@ import format from "date-fns/format";
 import isFuture from "date-fns/is_future";
 import isPast from "date-fns/is_past";
 import subSeconds from "date-fns/sub_seconds";
-import compareDesc from "date-fns/compare_desc";
-import get from "lodash.get";
+import clone from "lodash.clone";
 import upper from "lodash.capitalize";
+import get from "lodash.get";
 
 import config, { icons } from "../../config";
 import db from "../../lib/firebase";
 
 import css from "./head.css";
 
+var DEFAULT_START_TIME = "00:00",
+    DEFAULT_END_TIME   = "23:59",
+    DATE_FORMAT = "YYYY-MM-DD",
+    TIME_FORMAT = "HH:mm";
+
 export function controller(options) {
     var ctrl = this,
         ref  = options.ref,
         user = db.getAuth().uid,
 
-        publish   = options.data.published_at ? options.data.published_at : null,
-        unpublish = options.data.unpublished_at ? options.data.unpublished_at : null;
+        publishTs   = options.data.published_at ? options.data.published_at : null,
+        unpublishTs = options.data.unpublished_at ? options.data.unpublished_at : null;
 
-    ctrl.schedule   = false;
-    ctrl.unschedule = false;
+    ctrl.init = function() {
+        ctrl.schedule   = false;
 
-    if(publish) {
-        ctrl.start = {
-            date : format(publish, "YYYY-MM-DD"),
-            time : format(publish, "HH:mm")
-        };
-    } else {
-        ctrl.start = {
-            date : "",
-            time : get(config, "defaults.publish_start_time") || ""
-        };
-    }
+        if(publishTs) {
+            ctrl.start = {
+                date : format(publishTs, DATE_FORMAT),
+                time : format(publishTs, TIME_FORMAT),
+                ts   : publishTs
+            };
+        } else {
+            ctrl.start = ctrl.nulledStart();
+        }
 
-    if(unpublish) {
-        ctrl.end = {
-            date : format(unpublish, "YYYY-MM-DD"),
-            time : format(unpublish, "HH:mm")
-        };
-    } else {
-        ctrl.end = {
-            date : "",
-            time : ""
-        };
-    }
+        if(unpublishTs) {
+            ctrl.end = {
+                date : format(unpublishTs, DATE_FORMAT),
+                time : format(unpublishTs, TIME_FORMAT),
+                ts   : unpublishTs
+            };
+        } else {
+            ctrl.end = ctrl.nulledEnd();
+        }
+
+        ctrl.recalculateTimestamps();
+    };
 
     // Event handlers
     ctrl.update = function(section, field, value) {
         ctrl[section][field] = value;
+
+        if(section === "start" || section === "end") {
+            ctrl.recalculateTimestamps();
+        }
     };
 
     ctrl.toggle = function(force) {
@@ -57,178 +65,332 @@ export function controller(options) {
     };
 
     ctrl.publish = function() {
-        var start, end;
+        var startTs,
+            updated,
+            pubDateIsPast,
+            hasUnpubDate,
+            unpubDateIsFuture;
 
-        if(ctrl.schedule && ctrl.start.date) {
-            start = ctrl.start.date + " " + (ctrl.start.time || "00:00");
-        } else {
-            start = subSeconds(Date.now(), 10);
+        pubDateIsPast = Boolean(ctrl.start.ts) && isPast(ctrl.start.ts);
+
+        hasUnpubDate  = Boolean(ctrl.end.ts);
+        unpubDateIsFuture = hasUnpubDate && isFuture(ctrl.end.ts);
+
+        if(pubDateIsPast && (unpubDateIsFuture || !hasUnpubDate)) {
+            // Already currently published. No need to do anything.
+            return;
         }
 
-        if(ctrl.schedule && ctrl.end.date) {
-            end = ctrl.end.date + " " + (ctrl.end.time || "00:00");
-
-            if(compareDesc(end, start) !== -1) {
-                // TODO: handle
-                return console.error("Invalid end date");
-            }
-        }
-
-        return ref.update({
-            // TODO: Remove `published` field, it's deprecated
-            published      : parseInt(format(start, "x"), 10),
-            published_at   : parseInt(format(start, "x"), 10),
-            published_by   : user,
-            unpublished_at : end ? parseInt(format(end, "x"), 10) : null,
-            unpublished_by : end ? user : null
-        });
-    };
-
-    ctrl.unpublish = function() {
-        ref.update({
-            // TODO: Remove `published` field, it's deprecated
-            published    : null,
-            published_at : null,
-            published_by : null,
-
-            unpublished_at : db.TIMESTAMP,
-            unpublished_by : user
-        });
-
-        // TODO: THIS IS SUPER GROSS
-        ctrl.start = {
-            date : "",
-            time : ""
-        };
-
-        ctrl.end = {
-            date : "",
-            time : ""
-        };
-    };
-
-    ctrl.save = function(opts) {
         ctrl.saving = true;
 
         m.redraw();
 
-        ref.update({
-            fields : opts.data.fields,
-            name   : opts.data.name,
-            slug   : opts.data.slug || null
-        }, function() {
+        if(ctrl.start.ts) {
+            startTs = ctrl.start.ts;
+        } else {
+            startTs = subSeconds(Date.now(), 10);
+        }
+
+        updated = {
+            // TODO: Remove `published` field, it's deprecated
+            published    : startTs,
+            published_at : startTs,
+            published_by : user
+        };
+
+        debugger;
+
+        if(ctrl.end.ts) {
+            if(ctrl.start.ts > ctrl.end.ts) {
+                ctrl.end = ctrl.nulledEnd();
+
+                updated.unpublished_at = null;
+                updated.unpublished_by = null;
+
+                console.warn("Invalid end date. Resetting end date.");
+            }
+        }
+
+        ref.update(updated, function() {
             ctrl.saving = false;
 
             m.redraw();
         });
     };
+
+    ctrl.unpublish = function() {
+        var nowTs = Date.now(),
+            updated;
+
+        if(ctrl.end.ts && isPast(ctrl.end.ts)) {
+            // Already unpublished.
+            return;
+        }
+
+        ctrl.saving = true;
+
+        m.redraw();
+
+        updated = {
+            unpublished_at : nowTs,
+            unpublished_by : user
+        };
+
+        ctrl.end = {
+            date : format(nowTs, DATE_FORMAT),
+            time : format(nowTs, TIME_FORMAT),
+            ts   : nowTs
+        };
+
+        if(ctrl.start.ts) {
+            let startIsInvalid = ctrl.start.ts > nowTs;
+
+            if(startIsInvalid) {
+                ctrl.start = ctrl.nulledStart();
+            }
+        }
+
+        ref.update(updated, function() {
+            ctrl.saving = false;
+
+            m.redraw();
+        });
+    };
+
+    ctrl.save = function(opts) {
+        var updated = {};
+
+        ctrl.saving = true;
+
+        m.redraw();
+
+        updated = {
+            fields : opts.data.fields,
+            name   : opts.data.name,
+            slug   : opts.data.slug || null
+        };
+
+        updated = ctrl.addScheduleData(updated);
+
+        ref.update(updated, function() {
+            ctrl.saving = false;
+
+            m.redraw();
+        });
+    };
+
+    ctrl.addScheduleData = function(updated) {
+        if(!ctrl.invalidDates) {
+            let startTs = null,
+                endTs = null,
+                startTime = ctrl.start.time || DEFAULT_START_TIME,
+                endTime = ctrl.end.time || DEFAULT_END_TIME;
+
+            if(ctrl.start.date) {
+                startTs = ctrl.getTimestampFromStr(ctrl.start.date + " " + startTime);
+            }
+            if(ctrl.end.date) {
+                endTs = ctrl.getTimestampFromStr(ctrl.end.date + " " + endTime);
+            }
+
+            updated.published_at = startTs;
+            updated.unpublished_at = endTs;
+        }
+
+        if(options.data.published_at && !updated.published_at) {
+            // Publish date was removed. Save it.
+            updated.published    = null;
+            updated.published_at = null;
+            updated.published_by = null;
+        }
+
+        if(options.data.unpublished_at && !updated.unpublished_at) {
+            // Unpublish date was removed. Save it.
+            updated.unpublished_at = null;
+            updated.unpublished_by = null;
+        }
+
+        return updated;
+    };
+
+
+    ctrl.recalculateTimestamps = function() {
+        var start = ctrl.start,
+            end = ctrl.end;
+
+        if(start.date) {
+            start.ts = ctrl.getTimestampFromStr(start.date + " " + start.time);
+        }
+        if(end.date) {
+            end.ts = ctrl.getTimestampFromStr(end.date + " " + end.time);
+        }
+
+        if(start.date && end.date) {
+            ctrl.invalidDates = (start.ts > end.ts);
+        }
+    };
+
+    ctrl.getTimestampFromStr = function(str) {
+        return parseInt(format(str, "x"), 10);
+    };
+
+    ctrl.nulledStart = function() {
+        return ctrl.nulledDate(DEFAULT_START_TIME);
+    };
+
+    ctrl.nulledEnd = function() {
+        return ctrl.nulledDate(DEFAULT_END_TIME);
+    };
+
+    ctrl.nulledDate = function(time) {
+        return clone({
+            date : "",
+            time : time,
+            ts   : null
+        });
+    };    
+
+    ctrl.init();
 }
 
 export function view(ctrl, options) {
     var status  = "draft",
-        publish = options.data.published_at || options.data.published,
+        publishTs = options.data.published_at || options.data.published,
+        unpublishTs = options.data.unpublished_at || options.data.unpublished,
         future  = isFuture(ctrl.start.date + " " + ctrl.start.time),
+        wasUnpublished = unpublishTs < Date.now(),
         locked  = config.locked;
 
-    if(isFuture(publish)) {
+    if(isFuture(publishTs)) {
         status = "scheduled";
-    } else if(isPast(publish)) {
+    } else if(isPast(publishTs)) {
         status = "published";
+    } else if(isPast(unpublishTs)) {
+        status = "unpublished";
     }
 
-    return m("div", { class : css.head },
-        m("div", { class : css.main },
-            m("p", { class : css[status] },
-                upper(status)
-            ),
-            m("div", { class : css.actions },
-                ctrl.saving ?
-                    "SAVING..." : m("button", {
-                        // Attrs
-                        class    : css.save,
-                        title    : "Save your changes",
-                        disabled : locked || null,
+    function mSaveButton() {
+        return m("div", { class : css.actions },
+            ctrl.saving ?
+                "SAVING..." : m("button", {
+                    // Attrs
+                    class    : css.save,
+                    title    : "Save your changes",
+                    disabled : locked || null,
 
-                        // Events
-                        onclick : ctrl.save.bind(null, options)
-                    },
-                    m("svg", { class : css.icon },
-                        m("use", { href : icons + "#save" })
-                    ),
-                    "Save"
-                )
-            ),
-            m("div", { class : css.publishing },
-                m("button", {
-                        // Attrs
-                        class : css.schedule,
-                        title : "Schedule a publish",
-
-                        // Events
-                        onclick : ctrl.toggle.bind(null, undefined)
-                    },
-                    m("svg", { class : css.onlyIcon },
-                        m("use", { href : icons + "#schedule" })
-                    )
+                    // Events
+                    onclick : ctrl.save.bind(null, options)
+                },
+                m("svg", { class : css.icon },
+                    m("use", { href : icons + "#save" })
                 ),
-                m("button", {
-                        // Attrs
-                        class    : css.publish,
-                        title    : future ? "Schedule publish" : "Publish now",
-                        disabled : locked || null,
-
-                        // Events
-                        onclick : ctrl.publish
-                    },
-                    m("svg", { class : css.icon },
-                        m("use", { href : icons + (future ? "#schedule" : "#publish") })
-                    ),
-                    future ? "Schedule" : "Publish"
-                ),
-                status === "draft" ?
-                    null :
-                    m("button", {
-                            // Attrs
-                            class    : css.unpublish,
-                            title    : "Unpublish immediately",
-                            disabled : locked || null,
-
-                            // Events
-                            onclick : ctrl.unpublish
-                        },
-                        m("svg", { class : css.icon },
-                            m("use", { href : icons + "#remove" })
-                        ),
-                        "Unpublish"
-                    )
+                "Save"
             )
-        ),
-        ctrl.schedule ? m("div", { class : css.details },
+        );
+    }
+
+
+    function mScheduleButton() {
+        return m("button", {
+                // Attrs
+                class : css.schedule,
+                title : "Schedule a publish",
+
+                // Events
+                onclick : ctrl.toggle.bind(null, undefined)
+            },
+            m("svg", { class : css.onlyIcon },
+                m("use", { href : icons + "#schedule" })
+            )
+        );
+    }
+
+    function mPublishButton() {
+        var disabledClass = "";
+
+        // TODO Better implementation.
+        // if(ctrl.start.ts && isPast(ctrl.start.ts)) {
+        //     disabledClass = css.disabledBtn;
+        // }
+
+        return m("button", {
+                // Attrs
+                class : [
+                    css.publish,
+                    disabledClass
+                ].join(" "),
+                title    : future ? "Schedule publish" : "Already published",
+                disabled : locked || null,
+
+                // Events
+                onclick : ctrl.publish
+            },
+            m("svg", { class : css.icon },
+                m("use", { href : icons + (future ? "#schedule" : "#publish") })
+            ),
+            future ? "Schedule" : "Publish"
+        );
+    }
+
+    function mUnpublishButton() {
+        var disabledClass = "";
+
+        if(status === "draft") {
+            return null;
+        }
+
+        // TODO Better implementation.
+        // if(ctrl.end.ts && isPast(ctrl.end.ts)) {
+        //     disabledClass = css.disabledBtn;
+        // }
+
+        return m("button", {
+                // Attrs
+                class : [
+                    css.unpublish,
+                    disabledClass
+                ].join(" "),
+                title    : wasUnpublished ? "Already unpublished" : "Unpublish immediately",
+                disabled : locked || null,
+
+                // Events
+                onclick : ctrl.unpublish
+            },
+            m("svg", { class : css.icon },
+                m("use", { href : icons + "#remove" })
+            ),
+            "Unpublish"
+        );
+    }
+
+    function chronoInput(id, type, section, field) {
+        return m("input", {
+            class : css.date + ( ctrl.invalidDates ? " " + css.invalidDate : ""),
+            type  : type,
+            id    : id,
+            value : ctrl[section][field],
+
+            // Events
+            oninput : m.withAttr("value", ctrl.update.bind(ctrl, section, field))
+        });
+    }
+
+    function mDateScheduler() {
+        if(!ctrl.schedule) {
+            return null;
+        }
+
+
+        return m("div", { class : css.details },
             m("div", { class : css.start },
                 m("p",
                     m("label", { for : "published_at_date" }, "Publish at")
                 ),
                 m("p",
-                    m("input", {
-                        class : css.date,
-                        type  : "date",
-                        id    : "published_at_date",
-                        value : ctrl.start.date,
-
-                        // Events
-                        oninput : m.withAttr("value", ctrl.update.bind(ctrl, "start", "date"))
-                    })
+                    chronoInput("published_at_date", "date", "start", "date")
                 ),
                 m("p",
-                    m("input", {
-                        class : css.date,
-                        type  : "time",
-                        id    : "published_at_time",
-                        value : ctrl.start.time,
-
-                        // Events
-                        oninput : m.withAttr("value", ctrl.update.bind(ctrl, "start", "time"))
-                    })
+                    chronoInput("published_at_time", "time", "start", "time")
                 )
             ),
             m("div", { class : css.end },
@@ -236,28 +398,30 @@ export function view(ctrl, options) {
                     m("label", { for : "unpublished_at_date" }, "Until (optional)")
                 ),
                 m("p",
-                    m("input", {
-                        class : css.date,
-                        type  : "date",
-                        id    : "unpublished_at_date",
-                        value : ctrl.end.date,
-
-                        // Events
-                        oninput : m.withAttr("value", ctrl.update.bind(ctrl, "end", "date"))
-                    })
+                    chronoInput("unpublished_at_date", "date", "end", "date")
                 ),
                 m("p",
-                    m("input", {
-                        class : css.date,
-                        type  : "time",
-                        id    : "unpublished_at_time",
-                        value : ctrl.end.time,
-
-                        // Events
-                        oninput : m.withAttr("value", ctrl.update.bind(ctrl, "end", "time"))
-                    })
+                    chronoInput("unpublished_at_time", "time", "end", "time")
                 )
             )
-        ) : null
+        );
+    }
+
+
+    return m("div", { class : css.head },
+        m("div", { class : css.main },
+            m("p", { class : css[status] },
+                upper(status)
+            ),
+
+            mSaveButton(),
+
+            m("div", { class : css.publishing },
+                mScheduleButton(),
+                mPublishButton(),
+                mUnpublishButton()
+            )
+        ),
+        mDateScheduler()
     );
 }

--- a/src/pages/content-edit/head.js
+++ b/src/pages/content-edit/head.js
@@ -133,27 +133,9 @@ export function controller(options) {
     };
 
     ctrl.clearSchedule = function() {
-        var updated;
-
-        ctrl.saving = true;
-        m.redraw();
-
         ctrl.start = ctrl.nulledScheduleStart();
         ctrl.end   = ctrl.nulledScheduleEnd();
         ctrl.invalidDates = false;
-
-        updated = {
-            published      : null,
-            published_at   : null,
-            published_by   : null,
-            unpublished_at : null,
-            unpublished_by : null
-        };
-
-        ref.update(updated, function() {
-            ctrl.saving = false;
-            m.redraw();
-        });
     };
 
     ctrl.save = function(opts) {

--- a/src/pages/content-edit/head.js
+++ b/src/pages/content-edit/head.js
@@ -23,7 +23,10 @@ export function controller(options) {
         user = db.getAuth().uid,
 
         publishTs   = options.data.published_at ? options.data.published_at : null,
-        unpublishTs = options.data.unpublished_at ? options.data.unpublished_at : null;
+        unpublishTs = options.data.unpublished_at ? options.data.unpublished_at : null,
+
+        defaultStartTime = get(config, "defaults.publish_start_time") || DEFAULT_START_TIME,
+        defaultEndTime   = get(config, "defaults.publish_end_time")   || DEFAULT_END_TIME;
 
     ctrl.init = function() {
         ctrl.schedule   = false;
@@ -226,11 +229,11 @@ export function controller(options) {
     };
 
     ctrl.nulledScheduleStart = function() {
-        return ctrl.nulledDate(DEFAULT_START_TIME);
+        return ctrl.nulledDate(defaultStartTime);
     };
 
     ctrl.nulledScheduleEnd = function() {
-        return ctrl.nulledDate(DEFAULT_END_TIME);
+        return ctrl.nulledDate(defaultEndTime);
     };
 
     ctrl.nulledDate = function(time) {


### PR DESCRIPTION
- Break large Mithril object into named functions to improve readability and hopefully maintainability by breaking it into logical chunks.
- Use the `m` prefix on a function to indicate you'll get a mithril object back (or null).
- Add the timestamp itself to the `ctrl.start` and `ctrl.end` objects in addition to the `date` and `time` strings so we can do direct `ts` comparisons.
- Fix a bunch of logic around the Publish and Unpublish buttons and timestamp comparisons.

[ fixes #125 ]