### PR TITLE
Fix Select behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You can attach dom-specific attributes to most types by specifying an `attrs` ke
 
 ### Required Inputs
 
-Simply append the field's name with an asterisk `*` to mark the field `required`, the field label will also turn red.
+Append a field's name with an asterisk `*` to mark the field `required`, the field label will also turn red.
 
 ```js
     { 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ You can attach dom-specific attributes to most types by specifying an `attrs` ke
 }
 ```
 
+### Required Inputs
+
+Simply append the field's name with an asterisk `*` to mark the field `required`, the field label will also turn red.
+
+```js
+    { 
+        "Favorite Word?*": "text"
+    }
+```
+
 ### Example schema
 
 ```js

--- a/src/types/select.js
+++ b/src/types/select.js
@@ -5,7 +5,7 @@ import css from "./select.css";
 import multiple from "./lib/multiple.js";
 
 function findSelected(children) {
-    return children.find((option) => Boolean(option.selected));
+    return children.find((option) => option.selected);
 }
 
 function pleaseSelect() {

--- a/src/types/select.js
+++ b/src/types/select.js
@@ -28,14 +28,16 @@ export default multiple({
             optionObjs;
 
         if(hasSelected) {
-            // If the schema defines a selected option, don't
-            // add a "please select" but do set the value immediately.
-            optionObjs = children;
+            // If the schema defines a selected option, set the value immediately.
             ctrl.value(options, hasSelected.key, hasSelected.value);
+            optionObjs = children;
         } else {
-            // If we prepend a "please select" el, we need to
-            // adjust the index lookup in `onchange` via indexOffset
+            // If there is no selected option defined by the schema,
+            // then prepend a default "Please select..." option.
             optionObjs = [ pleaseSelect() ].concat(children);
+
+            // Which means we need to add an offset (via indexOffset)
+            // to the lookup-by-index that occurs in the `onchange` handler
             indexOffset = -1;
         }
 

--- a/src/types/select.js
+++ b/src/types/select.js
@@ -4,12 +4,40 @@ import assign from "lodash.assign";
 import css from "./select.css";
 import multiple from "./lib/multiple.js";
 
+function findSelected(children) {
+    return children.find((option) => Boolean(option.selected));
+}
+
+function pleaseSelect() {
+    return {
+        attrs    : {},
+        name     : "Please select an option...",
+        value    : "",
+        selected : true
+    };
+}
+
 export default multiple({
         multiple : false
     },
 
     function(ctrl, options, children) {
-        var field = options.field;
+        var field = options.field,
+            hasSelected = findSelected(children),
+            indexOffset = 0,
+            optionObjs;
+
+        if(hasSelected) {
+            // If the schema defines a selected option, don't
+            // add a "please select" but do set the value immediately.
+            optionObjs = children;
+            ctrl.value(options, hasSelected.key, hasSelected.value);
+        } else {
+            // If we prepend a "please select" el, we need to
+            // adjust the index lookup in `onchange` via indexOffset
+            optionObjs = [ pleaseSelect() ].concat(children);
+            indexOffset = -1;
+        }
 
         return m("select", assign({
                 // attrs
@@ -18,12 +46,13 @@ export default multiple({
                 // events
                 onchange : function(e) {
                     var tgt = e.target,
-                        opt = children[tgt.selectedIndex];
+                        opt = children[tgt.selectedIndex + indexOffset];
 
                     ctrl.value(options, opt.key, opt.value);
                 }
             }, field.attrs),
-            children.map(function(option) {
+            
+            optionObjs.map(function(option) {
                 return m("option", assign({}, option.attrs, {
                         value    : option.value,
                         selected : option.selected ? "selected" : null


### PR DESCRIPTION
Add a filler "Please Select" option if a `select` does not define a `selected` option. Set the value to the controller immediately if a `select` *does* define a `selected` option. [Fixes #123]

@tivac 